### PR TITLE
Fix bug when database ref 'pages' is empty

### DIFF
--- a/src/components/Admin/content/Pages.vue
+++ b/src/components/Admin/content/Pages.vue
@@ -31,7 +31,7 @@
                   </div>
                   <div class="dropdown-menu" id="dropdown-menu" role="menu">
                     <div class="dropdown-content">
-                      <a class="dropdown-item" v-for="page, key in pages" @click="selectPage(key)" v-if="page.name">
+                      <a class="dropdown-item" v-if="page" v-for="(page, key) in pages" :key="page.name" @click="selectPage(key)">
                         {{page.name}}
                       </a>
                       <hr class="dropdown-divider">


### PR DESCRIPTION
The first time I browsed to the 'pages' page in the admin, I was greeted with the error "TypeError: Cannot read property 'name' of null"