### PR TITLE
fix issues #92 & #94

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,11 @@ import VueQuillEditor from 'vue-quill-editor'
 import fontAwesome from '../node_modules/font-awesome/css/font-awesome.css'
 import bulma from '../node_modules/bulma/css/bulma.css'
 
+// import vue-quill-editor styles
+import 'quill/dist/quill.core.css'
+import 'quill/dist/quill.snow.css'
+import 'quill/dist/quill.bubble.css'
+
 Vue.use(VueFire)  // activate vuefire plugin
 Vue.use(VueQuillEditor)  // activate vue-quill-editor
 Vue.config.productionTip = false


### PR DESCRIPTION
unlike the old version, the new version of vue-quill-editor requires explicit importing of CSS files. This was causing a break in the UI of the editor. This pull request should fix it.