### PR TITLE
adding custome navigation menu builder (issue #70)

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -47,6 +47,9 @@
         // ".write": "auth != null && auth.uid == $uid && root.child('users').child(auth.uid).child('role').val() === 'admin' "
       }
     },
+    "nav": {
+      ".validate": true
+    },
     "$other": {
       ".validate": false
     }

--- a/src/components/Admin.vue
+++ b/src/components/Admin.vue
@@ -5,7 +5,7 @@
     <sidebar></sidebar>
 
     <!-- The admin page content -->
-    <div class="wrapper">
+    <div class="admin-wrapper">
       <section class="hero is-light is-medium is-bold" v-if="$route.name === 'Admin'">
         <div class="hero-body ">
           <div class="container has-text-centered">
@@ -63,7 +63,7 @@ export default {
 
 #admin
   font-family: 'Quicksand', sans-serif
-  .wrapper
+  .admin-wrapper
     width: calc(100% - 110px)
     position: absolute
     top: 52px

--- a/src/components/Admin/content/Settings.vue
+++ b/src/components/Admin/content/Settings.vue
@@ -54,6 +54,9 @@
         </div>
       </div>
     </div>
+
+    <!-- menu builder -->
+    <menu-builder></menu-builder>
   </div>
 </template>
 
@@ -61,6 +64,7 @@
 import { settingsRef } from '../../../config'
 import notifier from '../../../mixins/notifier'
 import modal from '@/components/shared/Modal'
+import MenuBuilder from './menu-builder'
 export default {
   name: 'settings',
   data () {
@@ -164,7 +168,8 @@ export default {
     this.updatesCounter++
   },
   components: {
-    modal
+    modal,
+    MenuBuilder
   }
 }
 

--- a/src/components/Admin/content/menu-builder.vue
+++ b/src/components/Admin/content/menu-builder.vue
@@ -20,7 +20,10 @@
           </div>
           <div class="field is-grouped">
             <div class="control">
-              <button class="button is-info" @click="addLink">Add</button>
+              <button v-if="action === 'new'" class="button is-info" @click="addLink">Add</button>
+              <button v-if="action === 'edit'" class="button is-info" @click="updateLink">
+                Update
+              </button>
             </div>
             <div class="control">
               <button class="button" @click="clear">Cancel</button>
@@ -40,6 +43,11 @@
 
               <!-- move down -->
               <span v-if="index !== menu.length - 1" class="has-text-danger" style="cursor: pointer;" @click="moveDown(item, menu[index + 1])">DOWN</span>
+
+              <!-- edit -->
+              <span class="has-text-info" style="cursor: pointer;" @click="editLink(item)">
+                EDIT
+              </span>
             </li>
           </ul>
         </div>
@@ -55,8 +63,10 @@ import { settingsRef, navRef } from '../../../config'
 export default {
   data () {
     return {
+      key: '',
       name: '',
-      path: ''
+      path: '',
+      action: 'new'
     }
   },
   firebase: {
@@ -75,12 +85,23 @@ export default {
       }
       this.clear()
     },
+    editLink (link) {
+      this.name = link.name
+      this.path = link.path
+      this.action = 'edit'
+      this.key = link['.key']
+    },
+    updateLink () {
+      this.$firebaseRefs.menu.child(this.key).set({name: this.name, path: this.path})
+      this.clear()
+    },
     removeLink (item) {
       this.$firebaseRefs.menu.child(item['.key']).remove()
     },
     clear () {
       this.name = ''
       this.path = ''
+      this.action = 'new'
     },
     moveUp (item, previousItem) {
       let itemCopy = Object.assign({}, item)

--- a/src/components/Admin/content/menu-builder.vue
+++ b/src/components/Admin/content/menu-builder.vue
@@ -34,6 +34,12 @@
             <li>
               |__ {{item.name}}: {{item.path}}
               <span class="delete has-text-danger" @click="removeLink(item)">delete</span>
+
+              <!-- move up -->
+              <span v-if="index !== 0" class="has-text-success" style="cursor: pointer;" @click="moveUp(item, menu[index - 1])">UP</span>
+
+              <!-- move down -->
+              <span v-if="index !== menu.length - 1" class="has-text-danger" style="cursor: pointer;" @click="moveDown(item, menu[index + 1])">DOWN</span>
             </li>
           </ul>
         </div>
@@ -75,6 +81,26 @@ export default {
     clear () {
       this.name = ''
       this.path = ''
+    },
+    moveUp (item, previousItem) {
+      let itemCopy = Object.assign({}, item)
+      let previousItemCopy = Object.assign({}, previousItem)
+
+      delete itemCopy['.key']
+      delete previousItemCopy['.key']
+
+      this.$firebaseRefs.menu.child(item['.key']).set(previousItemCopy)
+      this.$firebaseRefs.menu.child(previousItem['.key']).set(itemCopy)
+    },
+    moveDown (item, nextItem) {
+      let itemCopy = Object.assign({}, item)
+      let nextItemCopy = Object.assign({}, nextItem)
+
+      delete itemCopy['.key']
+      delete nextItemCopy['.key']
+
+      this.$firebaseRefs.menu.child(item['.key']).set(nextItemCopy)
+      this.$firebaseRefs.menu.child(nextItem['.key']).set(itemCopy)
     }
   }
 }

--- a/src/components/Admin/content/menu-builder.vue
+++ b/src/components/Admin/content/menu-builder.vue
@@ -60,8 +60,11 @@
 
               <!-- render children links -->
               <ul v-if="item.children" style="padding-left: 30px;">
-                <li v-for="(child, index) in item.children" :key="index">
+                <li v-for="(child, key) in item.children" :key="key">
                   |__ {{child.name}}: {{child.path}}
+
+                  <!-- remove sublink -->
+                  <span class="delete has-text-danger" @click="removeSubLink(key, item)">delete</span>
                 </li>
               </ul>
             </li>
@@ -155,6 +158,9 @@ export default {
         path: this.path
       })
       this.clear()
+    },
+    removeSubLink (key, parent) {
+      this.$firebaseRefs.menu.child(parent['.key']).child('children').child(key).remove()
     }
   }
 }

--- a/src/components/Admin/content/menu-builder.vue
+++ b/src/components/Admin/content/menu-builder.vue
@@ -5,6 +5,7 @@
     <div class="box">
       <div class="columns">
 
+        <!-- link form -->
         <div class="column">
           <div class="field">
             <label class="label">Name</label>
@@ -34,28 +35,19 @@
           </div>
         </div>
 
+        <!-- menu visualization -->
         <div class="column">
           <p class="is-size-4">menu</p>
           <ul v-for="(item, index) in menu" :key="index">
             <li>
               |__ {{item.name}}: {{item.path}}
 
-              <span class="delete has-text-danger" @click="removeLink(item)">delete</span>
-
-              <!-- move up -->
-              <span v-if="index !== 0" class="has-text-success" style="cursor: pointer;" @click="moveUp(item, menu[index - 1])">UP</span>
-
-              <!-- move down -->
-              <span v-if="index !== menu.length - 1" class="has-text-danger" style="cursor: pointer;" @click="moveDown(item, menu[index + 1])">DOWN</span>
-
-              <!-- edit -->
-              <span class="has-text-info" style="cursor: pointer;" @click="editLink(item)">
-                EDIT
-              </span>
-
-              <!-- add sub link -->
-              <span class="has-text-primary" style="cursor: pointer;" @click="addSubLink(item)">
-                SUB
+              <span class="link-actions">
+                <span class="has-text-danger fa fa-trash" @click="removeLink(item)"></span>
+                <span v-if="index !== 0" class="has-text-success fa fa-arrow-up" @click="moveUp(item, menu[index - 1])"></span>
+                <span v-if="index !== menu.length - 1" class="fa fa-arrow-down" @click="moveDown(item, menu[index + 1])"></span>
+                <span class="has-text-info fa fa-edit" @click="editLink(item)"></span>
+                <span class="has-text-primary fa fa-plus" @click="addSubLink(item)"></span>
               </span>
 
               <!-- render children links -->
@@ -63,8 +55,9 @@
                 <li v-for="(child, key) in item.children" :key="key">
                   |__ {{child.name}}: {{child.path}}
 
-                  <!-- remove sublink -->
-                  <span class="delete has-text-danger" @click="removeSubLink(key, item)">delete</span>
+                  <span class="link-actions">
+                    <span class="has-text-danger fa fa-trash" @click="removeSubLink(key, item)"></span>
+                  </span>
                 </li>
               </ul>
             </li>
@@ -165,3 +158,18 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+
+.link-actions {
+  display: none;
+  span {
+    cursor: pointer;
+  }
+}
+
+li:hover .link-actions {
+  display: inline;
+}
+
+</style>

--- a/src/components/Admin/content/menu-builder.vue
+++ b/src/components/Admin/content/menu-builder.vue
@@ -1,0 +1,81 @@
+<template>
+  <div>
+    <!-- navigation menu builder -->
+    <h3 class="is-size-3">Navigation Menu Builder</h3>
+    <div class="box">
+      <div class="columns">
+
+        <div class="column">
+          <div class="field">
+            <label class="label">Name</label>
+            <div class="control">
+              <input class="input" type="text" placeholder="Name (ex: Posts)" v-model="name">
+            </div>
+          </div>
+          <div class="field">
+            <label class="label">Path</label>
+            <div class="control">
+              <input class="input" type="text" placeholder="Path (ex: /admin/posts)" v-model="path">
+            </div>
+          </div>
+          <div class="field is-grouped">
+            <div class="control">
+              <button class="button is-info" @click="addLink">Add</button>
+            </div>
+            <div class="control">
+              <button class="button" @click="clear">Cancel</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="column">
+          <p class="is-size-4">menu</p>
+          <ul v-for="(item, index) in menu" :key="index">
+            <li>
+              |__ {{item.name}}: {{item.path}}
+              <span class="delete has-text-danger" @click="removeLink(item)">delete</span>
+            </li>
+          </ul>
+        </div>
+
+      </div>
+
+    </div>
+  </div>
+</template>
+
+<script>
+import { settingsRef, navRef } from '../../../config'
+export default {
+  data () {
+    return {
+      name: '',
+      path: ''
+    }
+  },
+  firebase: {
+    settings: {
+      source: settingsRef,
+      asObject: true
+    },
+    menu: {
+      source: navRef
+    }
+  },
+  methods: {
+    addLink () {
+      if (this.name && this.path) {
+        this.$firebaseRefs.menu.push({ name: this.name, path: this.path })
+      }
+      this.clear()
+    },
+    removeLink (item) {
+      this.$firebaseRefs.menu.child(item['.key']).remove()
+    },
+    clear () {
+      this.name = ''
+      this.path = ''
+    }
+  }
+}
+</script>

--- a/src/components/Admin/content/menu-builder.vue
+++ b/src/components/Admin/content/menu-builder.vue
@@ -80,6 +80,7 @@ export default {
   data () {
     return {
       key: '',
+      link: '', // {'.key', name, path}
       name: '',
       path: '',
       action: 'new'
@@ -106,9 +107,14 @@ export default {
       this.path = link.path
       this.action = 'edit'
       this.key = link['.key']
+      this.link = Object.assign({}, link)
     },
     updateLink () {
-      this.$firebaseRefs.menu.child(this.key).set({name: this.name, path: this.path})
+      delete this.link['.key']
+      this.link.name = this.name
+      this.link.path = this.path
+
+      this.$firebaseRefs.menu.child(this.key).set(this.link)
       this.clear()
     },
     removeLink (item) {

--- a/src/components/Admin/content/menu-builder.vue
+++ b/src/components/Admin/content/menu-builder.vue
@@ -24,6 +24,9 @@
               <button v-if="action === 'edit'" class="button is-info" @click="updateLink">
                 Update
               </button>
+              <button v-if="action === 'sub'" class="button is-info" @click="appendSubLink">
+                Add sub-link
+              </button>
             </div>
             <div class="control">
               <button class="button" @click="clear">Cancel</button>
@@ -36,6 +39,7 @@
           <ul v-for="(item, index) in menu" :key="index">
             <li>
               |__ {{item.name}}: {{item.path}}
+
               <span class="delete has-text-danger" @click="removeLink(item)">delete</span>
 
               <!-- move up -->
@@ -48,6 +52,18 @@
               <span class="has-text-info" style="cursor: pointer;" @click="editLink(item)">
                 EDIT
               </span>
+
+              <!-- add sub link -->
+              <span class="has-text-primary" style="cursor: pointer;" @click="addSubLink(item)">
+                SUB
+              </span>
+
+              <!-- render children links -->
+              <ul v-if="item.children" style="padding-left: 30px;">
+                <li v-for="(child, index) in item.children" :key="index">
+                  |__ {{child.name}}: {{child.path}}
+                </li>
+              </ul>
             </li>
           </ul>
         </div>
@@ -122,6 +138,17 @@ export default {
 
       this.$firebaseRefs.menu.child(item['.key']).set(nextItemCopy)
       this.$firebaseRefs.menu.child(nextItem['.key']).set(itemCopy)
+    },
+    addSubLink (link) {
+      this.action = 'sub'
+      this.key = link['.key']
+    },
+    appendSubLink () {
+      this.$firebaseRefs.menu.child(this.key).child('children').push({
+        name: this.name,
+        path: this.path
+      })
+      this.clear()
     }
   }
 }

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -6,17 +6,8 @@
         <a href="#">Website Logo</a>
       </h2>
       <nav>
-        <li>
-          <a href="#">Home</a>
-        </li>
-        <li>
-          <a href="#">Products</a>
-        </li>
-        <li>
-          <a href="#">About</a>
-        </li>
-        <li>
-          <a href="#">Contacts</a>
+        <li v-for="link in nav" :key="link">
+          <router-link :to="link.path">{{link.name}}</router-link>
         </li>
       </nav>
     </header>
@@ -158,7 +149,7 @@
 </template>
 
 <script>
-import { settingsRef, postsRef } from '../config'
+import { settingsRef, postsRef, navRef } from '../config'
 
 export default {
   name: 'home',
@@ -171,6 +162,9 @@ export default {
     posts: {
       source: postsRef,
       asObject: true
+    },
+    nav: {
+      source: navRef
     }
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -20,5 +20,6 @@ const pagesRef = db.ref('pages')
 const postsRef = db.ref('posts')
 const usersRef = db.ref('users')
 const mediaRef = db.ref('media')
+const navRef = db.ref('nav')
 
-export { postsRef, usersRef, settingsRef, pagesRef, mediaRef }
+export { postsRef, usersRef, settingsRef, pagesRef, mediaRef, navRef }


### PR DESCRIPTION
Hi Team,

I added a Navbar builder to the settings page. Now it includes:

- add/edit/delete/reorder links
- add sublinks and delete them
- make the homepage dynamic

currently, it supports just 1 level of nesting, if it is ok, I will add the edit and reorder functionalities to sublinks as well as other suggestions if exist, create an other pull request with them and close the issue #70 . Otherwise, if we must have more nesting levels, I will think how to implement it in the most efficient way. But I think ONE child level is Ok for now.

thanks