### PR TITLE
Remove default wildcard route pointed to home

### DIFF
--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -76,11 +76,6 @@ const routes = [
         ]
       }
     ]
-  },
-  {
-    path: '*',
-    name: 'default',
-    component: Home
   }
 ]
 


### PR DESCRIPTION
Removed the default route we added in routes which were pointing to Home as it was loading the homepage whenever we directly open the dynamic content routing page.