### PR TITLE
Fixed broken image-upload; undefined dowloadURL issue.

### DIFF
--- a/src/admin/pages/content/contents/ContentsEdit.vue
+++ b/src/admin/pages/content/contents/ContentsEdit.vue
@@ -89,6 +89,7 @@
 </template>
 
 <script>
+import Vue from 'vue'
 import firebase from 'firebase'
 
 import { mediaRef } from '@/admin/firebase_config'
@@ -125,12 +126,19 @@ export default {
       }
       this.updateContent(this.content)
     },
-    uploadFeaturedImage (e) {
+    uploadFeaturedImage (e, fieldName) {
       let file = e.target.files[0]
       let storageRef = firebase.storage().ref('images/' + file.name)
 
       storageRef.put(file).then((snapshot) => {
-        this.content.img = snapshot.downloadURL
+        return new Promise((resolve, reject) => {
+          snapshot.ref.getDownloadURL().then(url => {
+            snapshot.downloadURL = url
+            resolve(snapshot)
+          })
+        })
+      }).then((snapshot) => {
+        Vue.set(this.content, fieldName, snapshot.downloadURL)
         if (Object.values(this.media).find(e => e.path === snapshot.ref.fullPath)) return // this prevents duplicate entries in the media object
         this.$firebaseRefs.media.push({
           src: snapshot.downloadURL,

--- a/src/admin/pages/content/contents/ContentsNew.vue
+++ b/src/admin/pages/content/contents/ContentsNew.vue
@@ -90,6 +90,7 @@
 </template>
 
 <script>
+import Vue from 'vue'
 import firebase from 'firebase'
 import { mediaRef } from '@/admin/firebase_config'
 import editorOptions from '@/admin/utils/editor-options'
@@ -127,9 +128,15 @@ export default {
       let storageRef = firebase.storage().ref('images/' + file.name)
 
       storageRef.put(file).then((snapshot) => {
+        return new Promise((resolve, reject) => {
+          snapshot.ref.getDownloadURL().then(url => {
+            snapshot.downloadURL = url
+            resolve(snapshot)
+          })
+        })
+      }).then((snapshot) => {
         console.log(snapshot)
-        this.newContent[fieldName] = ''
-        this.newContent[fieldName] = snapshot.downloadURL
+        Vue.set(this.newContent, fieldName, snapshot.downloadURL)
         if (Object.values(this.media).find(e => e.path === snapshot.ref.fullPath)) return // this prevents duplicate entries in the media object
         this.$firebaseRefs.media.push({
           src: snapshot.downloadURL,


### PR DESCRIPTION
Looking at the Firebase#storage() documentation, the downloadURL must be
requested separatly from the the put-instruction and is not automatically available anymore,
The Vue.set() line is used to force Vue to refresh an image-field when
it previously was 'undefined'. 

(Only defined properties get reactive-setters by vue,
the if content[fieldName] yields undefined then you probably have to attach a reactive
listener manually using Vue.set() )