### PR TITLE
Fix for demo content uploading text/html files to images folder in database

### DIFF
--- a/src/admin/pages/Database.vue
+++ b/src/admin/pages/Database.vue
@@ -100,7 +100,11 @@ export default {
           let imageName = content.title ? `tamiat-${content.title}.png` : `tamiat-${content.author}.png`;
           let ImageRef = storageRef.child("images/" + imageName);
           let imgDownloadURL = "";
-
+          //if condition prevents the function from uploading an empty file when demo content does not have img property(Post, News...) Othervise it will upload a text/html file instead of an image since the promise returned undefined and the browser will say that the image was blocked by CORB (since it is a text/html file)
+          
+          if(!content.img){
+            content.img = "https://raw.githubusercontent.com/tamiat/tamiat/master/src/app/assets/img/coast.jpg"
+            }
           this.fetchBlob(content.img)
             .then(blob => {
               return ImageRef.put(blob);
@@ -112,7 +116,6 @@ export default {
               imgDownloadURL = downloadURL;
               content.created = Date.now();
               content.img = imgDownloadURL;
-
               return this.$firebaseRefs.contents
                 .child(hashKey + "/data")
                 .push(content);


### PR DESCRIPTION
When demo content does not have an img property with an image url the returned empty promise would be uploaded as a text/html file to the database storage and cause a CORB block of those files. added cindition that checks if there is an img property and if not it adds a default image.