### PR TITLE
deleting both instances of image set as WebsiteLogo

### DIFF
--- a/src/admin/pages/Media.vue
+++ b/src/admin/pages/Media.vue
@@ -38,10 +38,16 @@ export default {
       let storageRef = firebase.storage().ref(path)
       var that = this
       storageRef.delete().then(function () {
-        that.$firebaseRefs.media.child(key).remove()
+      that.$firebaseRefs.media.orderByValue().on("value", function(snapshot) {
+        snapshot.forEach(e => {
+          if (e.val().path === path)
+          that.$firebaseRefs.media.child(e.key).remove()
+        });
+      })
+        
       }).catch(function (error) {
         console.error(error)
-      })
+      }) 
     }
   }
 }

--- a/src/admin/pages/settings/Settings.vue
+++ b/src/admin/pages/settings/Settings.vue
@@ -209,16 +209,15 @@ export default {
             name: 'WebsiteLogo'
           }
           // let tempLogo = {...currentLogo}
-          //making sure that the image is uploaded into the media object and is registered in tamiat regerdless if it remains a logo or not so it can be used nonetheless
-          if (Object.values(this.media).find(e => e.path === snapshot.ref.fullPath)) return
-          else {
+          // making sure that the image is uploaded into the media object and is registered in tamiat regerdless if it remains a logo or not so it can be used nonetheless
+          if (Object.values(this.media).find(e => e.path === snapshot.ref.fullPath)) {
+          } else {
             this.$firebaseRefs.media.push({
               src: downloadURL,
               path: snapshot.ref.fullPath,
               name: snapshot.metadata.name
             })
           }
-          
           // the uploaded image either overrides the current logo or is set in a new media object as such
           if (currentLogo) {
           // delete tempLogo[key]


### PR DESCRIPTION
Since two instances of the image are created in the media section of the database, one named WebsiteLogo and the other just being a copy of the image that is there for general use if need be, there was a problem where, if for example WebsiteLogo was deleted the image would be removed from storage and so the second instance in media would point to something that no longer exists.A minor modification to the `deleteImage` function solved removal of both instances from media.