### PR TITLE
fixed select fields not being able to add options in ContentEdit component

### DIFF
--- a/src/admin/pages/content/contents/ContentsEdit.vue
+++ b/src/admin/pages/content/contents/ContentsEdit.vue
@@ -179,6 +179,10 @@ export default {
        * we are using Object.assign to copy the post by value not by reference
        * to prevent updating the post when typing */
       inputData: '',
+      select: {
+        selected:'',
+        options:[]
+      },
       selectOptionsRow: '',
       content: Object.assign(
         {},
@@ -249,14 +253,17 @@ export default {
     styleOptions (fieldName) {
       if (this.selectOptionsRow !== '') {
         if (!this.content[fieldName]) {
-          this.content[fieldName] = []
+          this.content[fieldName] = this.select
         }
         this.selectOptionsRow.split(',').forEach(tag => {
-          this.content[fieldName].push(`${tag.trim()}`)
+          this.select.options.push(`${tag.trim()}`)
         })
+        this.content[fieldName].options = [...this.content[fieldName].options, ...this.select.options]
+
         this.selectOptionsRow = ''
       }
     }
+    
   }
 }
 


### PR DESCRIPTION
It seems that I have overseen a critical error that would not allow select fields to be edited in the ContentsEdit component. This issue was previously fixed in ContentsNew component but it was for some reason overlooked on the ContentsEdit but it has promptly been fixed.